### PR TITLE
Fix set white as default background color

### DIFF
--- a/UI7Kit/UI7Color.m
+++ b/UI7Kit/UI7Color.m
@@ -56,4 +56,8 @@
     return [UIColor colorWith8bitRed:239 green:239 blue:244 alpha:255];
 }
 
++ (UIColor *)groupTableViewBackgroundColor {
+    return [UIColor colorWith8bitRed:239 green:239 blue:244 alpha:255];
+}
+
 @end

--- a/UI7Kit/UI7TableView.m
+++ b/UI7Kit/UI7TableView.m
@@ -42,7 +42,7 @@ UIColor *UI7TableViewGroupedViewPatternColor = nil;
 - (void)__updateVisibleCellsNow:(BOOL)flag { assert(NO); }
 
 - (void)_tableViewInit {
-    self.backgroundColor = [UIColor whiteColor];
+
 }
 
 - (void)_tableViewInitGrouped {
@@ -164,7 +164,9 @@ UIColor *UI7TableViewGroupedViewPatternColor = nil;
 - (id)initWithFrame:(CGRect)frame style:(UITableViewStyle)style {
     self = [self __initWithFrame:frame style:style];
     if (self) {
+        self.backgroundColor = [UI7Color whiteColor];
         if (style == UITableViewStyleGrouped) {
+            self.backgroundColor = [UI7Color groupTableViewBackgroundColor];
             [self _tableViewInitGrouped];
         }
         [self _tableViewInit];
@@ -174,7 +176,7 @@ UIColor *UI7TableViewGroupedViewPatternColor = nil;
 
 - (void)awakeFromNib {
     if (self.__style == UITableViewStyleGrouped && self.superview == nil && [self.backgroundColor isEqual:[UIColor clearColor]]) {
-        self.backgroundColor = [UIColor whiteColor];
+        self.backgroundColor = [UI7Color groupTableViewBackgroundColor];
     }
 }
 


### PR DESCRIPTION
when I use tag 0.8.16 all my Grouped TableView's which I create like:

`[[UITableViewController alloc] initWithStyle: UITableViewStyleGrouped];`

have a black background.

with this line of code I fix this for me.

but I'am not sure if I fix it on the right code line.
