### PR TITLE
Fix default shadow in iOS 6

### DIFF
--- a/UI7Kit/UI7NavigationBar.m
+++ b/UI7Kit/UI7NavigationBar.m
@@ -58,8 +58,9 @@ NSAPropertyAssignSetter(setNavigationBar, @"_navigationBar");
 
 - (void)_navigationBarInit {
     [self setBarStyle:self.barStyle];
-
-    [self setShadowImage:[[UIImage alloc] init]];
+    
+    if ([self respondsToSelector:@selector(setShadowImage:)])
+        [self setShadowImage:[[UIImage alloc] init]];
     
     UIGraphicsBeginImageContext(CGSizeMake(1.0, 3.0));
     CGContextRef context = UIGraphicsGetCurrentContext();

--- a/UI7Kit/UI7Toolbar.m
+++ b/UI7Kit/UI7Toolbar.m
@@ -19,6 +19,9 @@
 
 - (void)_toolbarInit {
     [self setBarStyle:self.barStyle];
+    
+    if ([self respondsToSelector:@selector(setShadowImage:forToolbarPosition:)])
+        [self setShadowImage:[[UIImage alloc] init] forToolbarPosition:UIToolbarPositionAny];
 
     UIGraphicsBeginImageContext(CGSizeMake(1.0, 3.0));
     CGContextRef context = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
At iOS 6 the Navigation Bar has by default a Shadow.
