### PR TITLE
Changed UI7Tableview headerView background color to clear. Otherwise it ...

### DIFF
--- a/UI7Kit/UI7TableView.m
+++ b/UI7Kit/UI7TableView.m
@@ -273,7 +273,7 @@ UIView *_UI7TableViewDelegateViewForHeaderInSection(id self, SEL _cmd, UITableVi
     if (title == nil) {
         if (grouped) {
             UIView *header = [[[UIView alloc] initWithFrame:CGRectMake(.0, .0, tableView.frame.size.width - 12.0f, UI7TableViewGroupedTableSectionSeperatorHeight)] autorelease];
-            header.backgroundColor = [UI7Color groupedTableViewSectionBackgroundColor];
+            header.backgroundColor = [UI7Color clearColor];
             return header;
         } else {
             return [[[UIView alloc] initWithFrame:CGRectZero] autorelease];
@@ -292,7 +292,7 @@ UIView *_UI7TableViewDelegateViewForHeaderInSection(id self, SEL _cmd, UITableVi
 
         view = [[[UIView alloc] initWithFrame:CGRectMake(.0, .0, tableView.frame.size.width, height)] autorelease];
         [view addSubview:label];
-        view.backgroundColor = [UI7Color groupedTableViewSectionBackgroundColor];
+        view.backgroundColor = [UI7Color clearColor];
     } else {
         UILabel *label = [[[UILabel alloc] initWithFrame:CGRectMake(.0, groupHeight, tableView.frame.size.width, height - groupHeight)] autorelease];
 


### PR DESCRIPTION
On iOS 7 if I change the background color of the tableview the area of additional padding that iOS7 provides inherited the background color of the tableview. With UI7Kit the background color of the padding added was being hard coded to [UI7Color groupedTableViewSectionBackgroundColor] regardless of what I set the background color of the tableView to be.
