### PR TITLE
Fix MPMediaPickerController issue on iOS6.

### DIFF
--- a/UI7Kit/UI7TableViewCell.m
+++ b/UI7Kit/UI7TableViewCell.m
@@ -213,7 +213,8 @@ UIImage *UI7TableViewCellAccessoryCheckmarkImageCreate() {
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
     [self __setBackgroundColor:backgroundColor];
-    if ([NSStringFromClass([self class]) hasPrefix:@"AB"]) {
+    NSString *className = NSStringFromClass([self class]);
+    if ([className hasPrefix:@"AB"] || [className hasPrefix:@"IU"]) {
         return;
     }
     self.backgroundView.backgroundColor = backgroundColor;


### PR DESCRIPTION
I fix following issue:
- MPMediaPickerController's text color becomes white in iOS6.
