### PR TITLE
fix UIButton setTitleColor:forState: not working bug

### DIFF
--- a/UI7Kit/UI7Button.m
+++ b/UI7Kit/UI7Button.m
@@ -124,7 +124,7 @@ UIColor *UI7ButtonDefaultTitleColor = nil;
             [self __setTitleColor:highlightedTextTitleColor forState:UIControlStateHighlighted];
             [self __setTitleColor:selectedTextTitleColor forState:UIControlStateSelected];
             [self __setTitleColor:disabledTextTitleColor forState:UIControlStateDisabled];
-
+            
         }   break;
         case UIButtonTypeDetailDisclosure:
         case UIButtonTypeInfoDark:


### PR DESCRIPTION
fix UIButton setTitleColor:forState: not working bug
