### PR TITLE
Fixed cocoapods 0.36.0 error

### DIFF
--- a/UI7Kit/UI7Button.m
+++ b/UI7Kit/UI7Button.m
@@ -156,7 +156,7 @@ UIColor *UI7ButtonDefaultTitleColor = nil;
     if (self != nil && [self.class.name isEqualToString:@"UIRoundedRectButton"]) {
         object_setClass(self, [UI7Button class]);
     }
-    self = [UI7Button methodImplementationForSelector:@selector(initWithCoder:)](self, _cmd, aDecoder);
+    self = ((id(*)(id, SEL, id))[UI7Button methodImplementationForSelector:@selector(initWithCoder:)])(self, _cmd, aDecoder);
     return self;
 }
 
@@ -277,7 +277,7 @@ UIColor *UI7ButtonDefaultTitleColor = nil;
     name = [@"__set" stringByAppendingString:@"TitleColor:forState:"];
     selector = NSSelectorFromString(name);
     impl = class_getMethodImplementation(self.class, selector);
-    impl(self, selector, color, state);
+    ((void(*)(id, SEL, id, UIControlState))impl)(self, selector, color, state);
 }
 
 - (UIColor *)___tintColor {

--- a/UI7Kit/UI7Color.m
+++ b/UI7Kit/UI7Color.m
@@ -54,7 +54,7 @@
 }
 
 + (UIColor *)groupedTableViewSectionBackgroundColor {
-    return [UIColor colorWithWhite:.0f alpha:0.063f];
+    return [UIColor colorWithRed:0.933 green:0.933 blue:0.957 alpha:1.000];
 }
 
 + (UIColor *)groupTableViewBackgroundColor {

--- a/UI7Kit/UI7TabBar.m
+++ b/UI7Kit/UI7TabBar.m
@@ -85,15 +85,15 @@ NSString *UI7TabBarStyle = @"UI7TabBarStyle";
     name = [@"_set" stringByAppendingString:@"LabelFont:"];
     selector = NSSelectorFromString(name);
     impl = class_getMethodImplementation(self.class, selector);
-    impl(self, selector, [UI7Font systemFontOfSize:10.0 attribute:UI7FontAttributeLight]);
+    ((void(*)(id, SEL, id))impl)(self, selector, [UI7Font systemFontOfSize:10.0 attribute:UI7FontAttributeLight]);
     name = [@"_set" stringByAppendingString:@"LabelShadowOffset:"];
     selector = NSSelectorFromString(name);
     impl = class_getMethodImplementation(self.class, selector);
-    impl(self, selector, CGSizeZero);
+    ((void(*)(id, SEL, CGSize))impl)(self, selector, CGSizeZero);
     name = [@"_set" stringByAppendingString:@"LabelTextColor:selectedTextColor:"];
     selector = NSSelectorFromString(name);
     impl = class_getMethodImplementation(self.class, selector);
-    impl(self, selector, [UIColor grayColor], self.tintColor);
+    ((void(*)(id, SEL, id, id))impl)(self, selector, [UIColor grayColor], self.tintColor);
 }
 
 @end

--- a/UI7Kit/UI7TabBarItem.m
+++ b/UI7Kit/UI7TabBarItem.m
@@ -160,7 +160,7 @@ NSString *UI7TabBarItemIconNames[] = {
         NSString *name = [@"set" stringByAppendingString:@"UnselectedImage:"];
         SEL selector = NSSelectorFromString(name);
         IMP impl = class_getMethodImplementation(self.class, selector);
-        impl(self, selector, self.image);
+        ((void(*)(id, SEL, id))impl)(self, selector, self.image);
     }
     return image;
 }


### PR DESCRIPTION
Fixed when using cocoapods 0.36.0
error : Too many arguments to function call, expected 0, have 3
